### PR TITLE
Fix item image changes not reverting on cancel

### DIFF
--- a/code/app/src/main/java/com/example/sigma_blue/fragments/EditFragment.java
+++ b/code/app/src/main/java/com/example/sigma_blue/fragments/EditFragment.java
@@ -140,6 +140,8 @@ public class EditFragment extends Fragment
             @Override
             public void onClick(View view)
             {
+                globalContext.getImageManager().updateFromItem(globalContext.getCurrentItem());
+                globalContext.setModifiedItem(new Item(globalContext.getCurrentItem()));
                 if (globalContext.getCurrentState() == ApplicationState.ADD_ITEM_FRAGMENT) {
                     // Cancel new item; Return to ViewListActivity
                     globalContext.setCurrentItem(null);


### PR DESCRIPTION
Image changes weren't actually saving to the item, but were displayed anyways.